### PR TITLE
Add the mandatory build-system section to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,7 @@ lxml = "4.6.3"
 [tool.poetry.scripts]
 kalamine = "kalamine.cli:make"
 xkalamine = "kalamine.cli_xkb:cli"
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,5 +33,5 @@ kalamine = "kalamine.cli:make"
 xkalamine = "kalamine.cli_xkb:cli"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Hi there!

I'm trying to build kalamine in nix using [poetry2nix](https://github.com/nix-community/poetry2nix), and I ran into the problem that the `pyproject.toml` doesn't have a `build-system` section.

As far as I understand, this is supposed to be a standard thing that poetry adds, so I'm not sure why it's missing here.

Anyway, I added it, it makes poetry2nix happy, so I though it's send a PR :)